### PR TITLE
[JENKINS-11998] Don't try to clean up without WS.

### DIFF
--- a/src/main/java/hudson/plugins/ws_cleanup/PreBuildCleanup.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/PreBuildCleanup.java
@@ -50,7 +50,9 @@ public class PreBuildCleanup extends BuildWrapper {
 		FilePath ws = build.getWorkspace();
 		if (ws != null) {
 			try {
-                if (patterns == null || patterns.isEmpty()) {
+                if (!ws.exists()) {
+                  return;
+                } else if (patterns == null || patterns.isEmpty()) {
 				    ws.deleteContents();
                 } else {
                     build.getWorkspace().act(new Cleanup(patterns));

--- a/src/main/java/hudson/plugins/ws_cleanup/WsCleanup.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/WsCleanup.java
@@ -1,6 +1,7 @@
 package hudson.plugins.ws_cleanup;
 
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
@@ -39,13 +40,17 @@ public class WsCleanup extends Notifier {
     
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        FilePath workspace = build.getWorkspace();
+        if (workspace == null || !workspace.exists()) {
+          return true;
+        }
 
         listener.getLogger().append("\nDeleting project workspace... ");
         try {
             if (patterns == null || patterns.isEmpty()) {
-                build.getWorkspace().deleteRecursive();
+                workspace.deleteRecursive();
             } else {
-                build.getWorkspace().act(new Cleanup(patterns));
+                workspace.act(new Cleanup(patterns));
             }
             listener.getLogger().append("done\n\n");
         } catch (InterruptedException ex) {


### PR DESCRIPTION
This checks for ws.exists() before doing any work on it - this prevents an
exception when using org.apache.tools.ant.DirectoryScanner.scan on an
nonexistant directory.
