### PR TITLE
Fix JENKINS-17761: configurable based on build status

### DIFF
--- a/src/main/resources/hudson/plugins/ws_cleanup/WsCleanup/config.jelly
+++ b/src/main/resources/hudson/plugins/ws_cleanup/WsCleanup/config.jelly
@@ -26,9 +26,13 @@
 		<f:entry title="${%Apply pattern also on directories}">
 			<f:checkbox field="deleteDirs" checked="${it.deleteDirs}" />
 		</f:entry>
-		<f:entry title="${%Skip when build failed}">
-			<f:checkbox field="skipWhenFailed" checked="${it.skipWhenFailed}" />
-		</f:entry>
+		<f:entry title="${%Clean when status is}">
+            <f:checkbox field="cleanWhenSuccess" checked="${it.cleanWhenSuccess}" title="${%Success}"/>
+            <f:checkbox field="cleanWhenUnstable" checked="${it.cleanWhenUnstable}" title="${%Unstable}"/>
+            <f:checkbox field="cleanWhenFailure" checked="${it.cleanWhenFailure}" title="${%Failure}"/>
+            <f:checkbox field="cleanWhenNotBuilt" checked="${it.cleanWhenNotBuilt}" title="${%Not Built}"/>
+            <f:checkbox field="cleanWhenAborted" checked="${it.cleanWhenAborted}" title="${%Aborted}"/>
+        </f:entry>
 		<f:entry title="${%Don't fail the build if cleanup fails}" help="/plugin/ws-cleanup/help/notFailBuild.html">
 			<f:checkbox field="notFailBuild" checked="${it.notFailBuild}" />
 		</f:entry>


### PR DESCRIPTION
Added options to make ws-cleanup run/not run on any given status, not just on success.

![image](https://f.cloud.github.com/assets/1687436/456320/fa4c0050-b367-11e2-948e-b97f0e8ca6ab.png)
