### PR TITLE
Allow external tool to be used for deletion (such as unlocker)

### DIFF
--- a/src/main/java/hudson/plugins/ws_cleanup/Cleanup.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/Cleanup.java
@@ -22,12 +22,14 @@ class Cleanup implements FileCallable<Object> {
     private String delete_command = null;
     private BuildListener listener = null;
 
-    public Cleanup(List<Pattern> patterns, boolean deleteDirs, EnvironmentVariablesNodeProperty environment, BuildListener listener) {
+    public Cleanup(List<Pattern> patterns, boolean deleteDirs, EnvironmentVariablesNodeProperty environment, String command, BuildListener listener) {
 
         this.deleteDirs = deleteDirs;
         try {
-            this.delete_command = environment.getEnvVars().get("delete_command");            
-            
+            this.delete_command = environment.getEnvVars().expand(command);            
+            if(this.delete_command.length() == 0) {
+                this.delete_command = null;
+            }
         } catch( NullPointerException ex ) {
             this.delete_command = null;
         } 

--- a/src/main/java/hudson/plugins/ws_cleanup/PreBuildCleanup.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/PreBuildCleanup.java
@@ -27,12 +27,14 @@ public class PreBuildCleanup extends BuildWrapper {
 	private final List<Pattern> patterns;
 	private final boolean deleteDirs;
 	private final String cleanupParameter;
+        private final String externalDelete;
 
 	@DataBoundConstructor
-	public PreBuildCleanup(List<Pattern> patterns, boolean deleteDirs, String cleanupParameter) {
+	public PreBuildCleanup(List<Pattern> patterns, boolean deleteDirs, String cleanupParameter, String externalDelete) {
 		this.patterns = patterns;
 		this.deleteDirs = deleteDirs;
 		this.cleanupParameter = cleanupParameter;
+                this.externalDelete = externalDelete;
 	}
 
 	public List<Pattern> getPatterns(){
@@ -47,6 +49,10 @@ public class PreBuildCleanup extends BuildWrapper {
 		return this.cleanupParameter;
 	}
 	
+        public String getExternalDelete() {
+            return this.externalDelete;
+        }
+        
 	@Override
 	public DescriptorImpl getDescriptor() {
 		return (DescriptorImpl) super.getDescriptor();
@@ -84,7 +90,7 @@ public class PreBuildCleanup extends BuildWrapper {
 							return;
 						if (patterns == null || patterns.isEmpty()) {
 							build.getWorkspace().act(new Cleanup(patterns,deleteDirs, build.getBuiltOn().getNodeProperties().get(
-                                EnvironmentVariablesNodeProperty.class), listener));
+                                EnvironmentVariablesNodeProperty.class), externalDelete, listener));
 						}
 
 						listener.getLogger().append("done\n\n");

--- a/src/main/java/hudson/plugins/ws_cleanup/WsCleanupMatrixAggregator.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/WsCleanupMatrixAggregator.java
@@ -24,10 +24,11 @@ public class WsCleanupMatrixAggregator extends MatrixAggregator {
     private final boolean cleanWhenFailure;
     private final boolean cleanWhenNotBuilt;
     private final boolean cleanWhenAborted;
+    private final String externalDelete;
 	
 	public WsCleanupMatrixAggregator(MatrixBuild build, Launcher launcher, BuildListener listener, List<Pattern> patterns, 
 			boolean deleteDirs, final boolean cleanWhenSuccess, final boolean cleanWhenUnstable, final boolean cleanWhenFailure,
-            final boolean cleanWhenNotBuilt, final boolean cleanWhenAborted, final boolean notFailBuild) {
+            final boolean cleanWhenNotBuilt, final boolean cleanWhenAborted, final boolean notFailBuild, final String externalDelete) {
 		super(build, launcher, listener);
 		this.patterns = patterns;
 		this.deleteDirs = deleteDirs;
@@ -37,6 +38,7 @@ public class WsCleanupMatrixAggregator extends MatrixAggregator {
         this.cleanWhenNotBuilt = cleanWhenNotBuilt;
         this.cleanWhenAborted = cleanWhenAborted;
 		this.notFailBuild = notFailBuild;
+        this.externalDelete = externalDelete;
     }
 	
 	public boolean endBuild() throws InterruptedException, IOException {
@@ -100,7 +102,7 @@ public class WsCleanupMatrixAggregator extends MatrixAggregator {
                 workspace.deleteRecursive();
             } else {
                 workspace.act(new Cleanup(patterns,deleteDirs, build.getBuiltOn().getNodeProperties().get(
-                                EnvironmentVariablesNodeProperty.class), listener));
+                                EnvironmentVariablesNodeProperty.class), externalDelete, listener));
             }
             listener.getLogger().append("done\n\n");
         } catch (Exception ex) {

--- a/src/main/resources/hudson/plugins/ws_cleanup/PreBuildCleanup/config.jelly
+++ b/src/main/resources/hudson/plugins/ws_cleanup/PreBuildCleanup/config.jelly
@@ -1,33 +1,36 @@
 <!-- The MIT License Copyright (c) 2010, CloudBees Inc, Nicolas De loof Permission 
-	is hereby granted, free of charge, to any person obtaining a copy of this 
-	software and associated documentation files (the "Software"), to deal in 
-	the Software without restriction, including without limitation the rights 
-	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-	copies of the Software, and to permit persons to whom the Software is furnished 
-	to do so, subject to the following conditions: The above copyright notice 
-	and this permission notice shall be included in all copies or substantial 
-	portions of the Software. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY 
-	OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
-	OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-	IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-	DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-	ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-	DEALINGS IN THE SOFTWARE. -->
+is hereby granted, free of charge, to any person obtaining a copy of this 
+software and associated documentation files (the "Software"), to deal in 
+the Software without restriction, including without limitation the rights 
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is furnished 
+to do so, subject to the following conditions: The above copyright notice 
+and this permission notice shall be included in all copies or substantial 
+portions of the Software. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY 
+OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+DEALINGS IN THE SOFTWARE. -->
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
-	<f:advanced align="left">
-		<f:entry title="${%Patterns for files to be deleted}" help="/plugin/ws-cleanup/help/patterns.html">
-			<f:repeatable field="patterns">
-				<st:include page="config.jelly" class="hudson.plugins.ws_cleanup.Pattern" />
-				<div align="right">
-					<f:repeatableDeleteButton />
-				</div>
-			</f:repeatable>
-		</f:entry>
-		<f:entry title="${%Apply pattern also on directories}">
-			<f:checkbox field="deleteDirs" checked="${it.deleteDirs}" />
-		</f:entry>
-		<f:entry title="${%Check parameter}" help="/plugin/ws-cleanup/help/cleanupParameter.html">
-			<f:textbox field="cleanupParameter" />
-		</f:entry>
-	</f:advanced>
+    <f:advanced align="left">
+        <f:entry title="${%Patterns for files to be deleted}" help="/plugin/ws-cleanup/help/patterns.html">
+            <f:repeatable field="patterns">
+                <st:include page="config.jelly" class="hudson.plugins.ws_cleanup.Pattern" />
+                <div align="right">
+                    <f:repeatableDeleteButton />
+                </div>
+            </f:repeatable>
+        </f:entry>
+        <f:entry title="${%Apply pattern also on directories}">
+            <f:checkbox field="deleteDirs" checked="${it.deleteDirs}" />
+        </f:entry>
+        <f:entry title="${%Check parameter}" help="/plugin/ws-cleanup/help/cleanupParameter.html">
+            <f:textbox field="cleanupParameter" />
+        </f:entry>
+        <f:entry title="${%External Deletion Command}" help="/plugin/ws-cleanup/help/externalDelete.html">
+            <f:textbox field="externalDelete" />
+        </f:entry>
+    </f:advanced>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/ws_cleanup/WsCleanup/config.jelly
+++ b/src/main/resources/hudson/plugins/ws_cleanup/WsCleanup/config.jelly
@@ -1,45 +1,49 @@
 <!-- The MIT License Copyright (c) 2010, CloudBees Inc, Nicolas De loof Permission 
-	is hereby granted, free of charge, to any person obtaining a copy of this 
-	software and associated documentation files (the "Software"), to deal in 
-	the Software without restriction, including without limitation the rights 
-	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-	copies of the Software, and to permit persons to whom the Software is furnished 
-	to do so, subject to the following conditions: The above copyright notice 
-	and this permission notice shall be included in all copies or substantial 
-	portions of the Software. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY 
-	OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
-	OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-	IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-	DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-	ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-	DEALINGS IN THE SOFTWARE. -->
+is hereby granted, free of charge, to any person obtaining a copy of this 
+software and associated documentation files (the "Software"), to deal in 
+the Software without restriction, including without limitation the rights 
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is furnished 
+to do so, subject to the following conditions: The above copyright notice 
+and this permission notice shall be included in all copies or substantial 
+portions of the Software. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY 
+OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+DEALINGS IN THE SOFTWARE. -->
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
-	<f:advanced align="left">
-		<f:entry title="${%Patterns for files to be deleted}" help="/plugin/ws-cleanup/help/patterns.html">
-			<f:repeatable field="patterns">
-				<st:include page="config.jelly" class="hudson.plugins.ws_cleanup.Pattern" />
-				<div align="right">
-					<f:repeatableDeleteButton />
-				</div>
-			</f:repeatable>
-		</f:entry>
-		<f:entry title="${%Apply pattern also on directories}">
-			<f:checkbox field="deleteDirs" checked="${it.deleteDirs}" />
-		</f:entry>
-		<f:entry title="${%Clean when status is}">
+    <f:advanced align="left">
+        <f:entry title="${%Patterns for files to be deleted}" help="/plugin/ws-cleanup/help/patterns.html">
+            <f:repeatable field="patterns">
+                <st:include page="config.jelly" class="hudson.plugins.ws_cleanup.Pattern" />
+                <div align="right">
+                    <f:repeatableDeleteButton />
+                </div>
+            </f:repeatable>
+        </f:entry>
+        <f:entry title="${%Apply pattern also on directories}">
+            <f:checkbox field="deleteDirs" checked="${it.deleteDirs}" />
+        </f:entry>
+        <f:entry title="${%Clean when status is}">
             <f:checkbox field="cleanWhenSuccess" checked="${it.cleanWhenSuccess}" default="true" title="${%Success}"/>
             <f:checkbox field="cleanWhenUnstable" checked="${it.cleanWhenUnstable}" default="true" title="${%Unstable}"/>
             <f:checkbox field="cleanWhenFailure" checked="${it.cleanWhenFailure}" default="true" title="${%Failure}"/>
             <f:checkbox field="cleanWhenNotBuilt" checked="${it.cleanWhenNotBuilt}" default="true" title="${%Not Built}"/>
             <f:checkbox field="cleanWhenAborted" checked="${it.cleanWhenAborted}" default="true" title="${%Aborted}"/>
         </f:entry>
-		<f:entry title="${%Don't fail the build if cleanup fails}" help="/plugin/ws-cleanup/help/notFailBuild.html">
-			<f:checkbox field="notFailBuild" checked="${it.notFailBuild}" />
-		</f:entry>
+        <f:entry title="${%Don't fail the build if cleanup fails}" help="/plugin/ws-cleanup/help/notFailBuild.html">
+            <f:checkbox field="notFailBuild" checked="${it.notFailBuild}" />
+        </f:entry>
         <j:if test="${instance.isMatrixProject(it)}">
-			<f:entry title="${%Cleanup workspace of matrix parent}" help="/plugin/ws-cleanup/help/cleanupMatrixParent.html">
-				<f:checkbox field="cleanupMatrixParent" checked="${it.cleanupMatrixParent}" />
-			</f:entry>
-		</j:if>
-	</f:advanced>
+            <f:entry title="${%Cleanup workspace of matrix parent}" help="/plugin/ws-cleanup/help/cleanupMatrixParent.html">
+                <f:checkbox field="cleanupMatrixParent" checked="${it.cleanupMatrixParent}" />
+            </f:entry>
+        </j:if>
+        
+        <f:entry title="${%External Deletion Command}" help="/plugin/ws-cleanup/help/externalDelete.html">
+            <f:textbox field="externalDelete" />
+        </f:entry>
+    </f:advanced>
 </j:jelly>

--- a/src/main/webapp/help/externalDelete.html
+++ b/src/main/webapp/help/externalDelete.html
@@ -1,0 +1,40 @@
+<div>
+    <p>If set, an external deletion program will be run against files and directories. </p>
+
+    <p>Syntax:
+        <code>
+            program_name [program options] %s
+        </code>
+    </p>
+    <p>
+        Where program_name is the program to use, path, or environment variable.  
+        <code>program options</code> are any switches to send to the program.
+        <code>%s</code> will be replaced with the path to be deleted dynamically.
+    </p>
+    <p>
+        An empty string, after environment variable expansion uses the default 
+        deletion utility.
+    </p>
+    <p>
+        Environment variables can be used with the following syntax: <code>${env_var}</code>
+    </p>        
+    <p>
+        Examples:
+        <pre>
+            Unlocker: 
+                "C:\Program Files\Unlocker\unlocker.exe" %s /D /S
+            
+            Unlocker on Windows Nodes:
+                ${delete_command}
+               
+                with the following environment variable defined on windows nodes:
+                delete_command = "C:\Program Files\Unlocker\unlocker.exe" %s /D /S
+
+                And on other nodes:
+                delete_command = "" (An empty string uses the default functionality)            
+
+            Shred:
+                shred -u %s
+        </pre>
+    </p>
+</div>


### PR DESCRIPTION
- If a node has delete_command environment variable, it will be used
  instead of the default functionality.

The format of the command is:
"path/to/executable" [options] %s

Unlocker, for example:
"C:\Program Files\Unlocker\unlocker.exe" %s /D /S
