### PR TITLE
Fix JENKINS-13444: Do not follow symlinks with ant pattern

### DIFF
--- a/src/main/java/hudson/plugins/ws_cleanup/Cleanup.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/Cleanup.java
@@ -78,6 +78,7 @@ class Cleanup implements FileCallable<Object> {
             }
             
             DirectoryScanner ds = new DirectoryScanner();
+            ds.setFollowSymlinks(false);
             ds.setBasedir(f);
             ArrayList<String> includes = new ArrayList<String>();
             ArrayList<String> excludes = new ArrayList<String>();
@@ -103,11 +104,14 @@ class Cleanup implements FileCallable<Object> {
             if (deleteDirs) {
                 length += ds.getIncludedDirsCount();
             }
+            final String[] nonFollowedSymlinks = ds.getNotFollowedSymlinks();
+            length += nonFollowedSymlinks.length;
             String[] toDelete = new String[length];
             System.arraycopy(ds.getIncludedFiles(), 0, toDelete, 0, ds.getIncludedFilesCount());
             if (deleteDirs) {
                 System.arraycopy(ds.getIncludedDirectories(), 0, toDelete, ds.getIncludedFilesCount(), ds.getIncludedDirsCount());
             }
+            System.arraycopy(nonFollowedSymlinks, 0, toDelete, ds.getIncludedFilesCount() + ds.getIncludedDirsCount(), nonFollowedSymlinks.length);
             for (String path : toDelete) {
                 if (delete_command != null) {
                     temp_command = delete_command.replaceAll("%s", "\"" + StringEscapeUtils.escapeJava((new File(f, path)).getPath()) + "\"");


### PR DESCRIPTION
Do not follow symlinks when ant patterns are used. To make it the same
behaviour as without ant patterns.

See https://issues.jenkins-ci.org/browse/JENKINS-13444

I have only done a minor amount of testing on this patch.
