### PR TITLE
Add a property to ignore workspace clean if the build is done on master

### DIFF
--- a/src/main/java/hudson/plugins/ws_cleanup/WsCleanupMatrixAggregator.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/WsCleanupMatrixAggregator.java
@@ -17,6 +17,7 @@ public class WsCleanupMatrixAggregator extends MatrixAggregator {
 	
 	private final List<Pattern> patterns;
     private final boolean deleteDirs;
+    private final boolean ignoreCleanupOnMaster;
     private final boolean notFailBuild;
 
     private final boolean cleanWhenSuccess;
@@ -27,11 +28,12 @@ public class WsCleanupMatrixAggregator extends MatrixAggregator {
     private final String externalDelete;
 	
 	public WsCleanupMatrixAggregator(MatrixBuild build, Launcher launcher, BuildListener listener, List<Pattern> patterns, 
-			boolean deleteDirs, final boolean cleanWhenSuccess, final boolean cleanWhenUnstable, final boolean cleanWhenFailure,
+			boolean deleteDirs, boolean ignoreCleanupOnMaster, final boolean cleanWhenSuccess, final boolean cleanWhenUnstable, final boolean cleanWhenFailure,
             final boolean cleanWhenNotBuilt, final boolean cleanWhenAborted, final boolean notFailBuild, final String externalDelete) {
 		super(build, launcher, listener);
 		this.patterns = patterns;
 		this.deleteDirs = deleteDirs;
+		this.ignoreCleanupOnMaster = ignoreCleanupOnMaster;
         this.cleanWhenSuccess = cleanWhenSuccess;
         this.cleanWhenUnstable = cleanWhenUnstable;
         this.cleanWhenFailure = cleanWhenFailure;
@@ -61,6 +63,10 @@ public class WsCleanupMatrixAggregator extends MatrixAggregator {
     }
 
 	private boolean doWorkspaceCleanup() throws IOException, InterruptedException {
+		if(ignoreCleanupOnMaster &&  "".equals(build.getBuiltOn().getNodeName())){
+			listener.getLogger().append("\nBuild is on master node, deleting project workspace is cancelled.\n");
+			return true;
+		}
 		listener.getLogger().append("\nDeleting matrix project workspace... \n");
 		
 		//TODO do we want to keep keep child workpsaces if run on the same machine? Make it optional?

--- a/src/main/resources/hudson/plugins/ws_cleanup/Messages.properties
+++ b/src/main/resources/hudson/plugins/ws_cleanup/Messages.properties
@@ -1,2 +1,3 @@
 WsCleanup.Delete_workspace=Delete workspace when build is done
 PreBuildCleanup.Delete_workspace=Delete workspace before build starts
+WsCleanup.ignore_on_master=Ignore cleanup on master

--- a/src/main/resources/hudson/plugins/ws_cleanup/PreBuildCleanup/config.jelly
+++ b/src/main/resources/hudson/plugins/ws_cleanup/PreBuildCleanup/config.jelly
@@ -15,6 +15,11 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE. -->
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
     <f:advanced align="left">
+    
+        <f:entry title="${%Ignore cleanup on master}">
+            <f:checkbox field="ignoreCleanupOnMaster" checked="${it.ignoreCleanupOnMaster}" />
+        </f:entry>
+        
         <f:entry title="${%Patterns for files to be deleted}" help="/plugin/ws-cleanup/help/patterns.html">
             <f:repeatable field="patterns">
                 <st:include page="config.jelly" class="hudson.plugins.ws_cleanup.Pattern" />

--- a/src/main/resources/hudson/plugins/ws_cleanup/WsCleanup/config.jelly
+++ b/src/main/resources/hudson/plugins/ws_cleanup/WsCleanup/config.jelly
@@ -15,6 +15,11 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE. -->
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
     <f:advanced align="left">
+    
+        <f:entry title="${%Ignore cleanup on master}">
+            <f:checkbox field="ignoreCleanupOnMaster" checked="${it.ignoreCleanupOnMaster}" />
+        </f:entry>
+        
         <f:entry title="${%Patterns for files to be deleted}" help="/plugin/ws-cleanup/help/patterns.html">
             <f:repeatable field="patterns">
                 <st:include page="config.jelly" class="hudson.plugins.ws_cleanup.Pattern" />


### PR DESCRIPTION
In my environment, I build all job in ramdisk slave and so I've to clean workspace after build done. But sometimes, I need to keep the workspace (to debug it for example).

So I've added this feature (which is correctly working for our environment).