### PR TITLE
Only log external delete command on errors

### DIFF
--- a/src/main/java/hudson/plugins/ws_cleanup/Cleanup.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/Cleanup.java
@@ -130,20 +130,14 @@ class Cleanup extends RemoteCleaner implements FileCallable<Object> {
         List<String> cmdList = new ArrayList<String>();
         java.util.regex.Pattern p = java.util.regex.Pattern.compile("\"([^\"]+)\"|(\\S+)");
         java.util.regex.Matcher m = p.matcher(tempCommand);
-        StringBuilder finalCmd = new StringBuilder("Using command: ");
         while (m.find()) {
             if (m.group(1) != null) {
                 cmdList.add(m.group(1));
-                finalCmd.append(m.group(1));
             }
             if (m.group(2) != null) {
                 cmdList.add(m.group(2));
-                finalCmd.append(m.group(2));
             }
-            finalCmd.append(" ");
         }
-
-        this.listener.getLogger().println(WsCleanup.LOG_PREFIX + finalCmd.toString());
         return cmdList;
     }
 
@@ -151,7 +145,7 @@ class Cleanup extends RemoteCleaner implements FileCallable<Object> {
         Process deletProc = new ProcessBuilder(cmdList).start();
         int exit = deletProc.waitFor();
         if (exit != 0) {
-            listener.error("Cleanup command failed with code %d:", exit);
+            listener.error("Cleanup command `%s' failed with code %d:", Util.join(cmdList, " "), exit);
             InputStream err = deletProc.getErrorStream();
             try {
                 Util.copyStream(err, listener.getLogger());

--- a/src/test/java/hudson/plugins/ws_cleanup/CleanupTest.java
+++ b/src/test/java/hudson/plugins/ws_cleanup/CleanupTest.java
@@ -72,11 +72,6 @@ public class CleanupTest {
 
         p.getBuildWrappersList().add(new PreBuildCleanup(Collections.<Pattern>emptyList(), false, null, "rm %s"));
         FreeStyleBuild b = j.buildAndAssertSuccess(p);
-
-        final String log = b.getLog();
-        assertThat(log, containsString(
-                "Using command: rm " + b.getWorkspace().getRemote() + "/" + filename
-        ));
     }
 
     @Test
@@ -192,7 +187,8 @@ public class CleanupTest {
         FreeStyleBuild build = j.buildAndAssertSuccess(p);
         String log = build.getLog();
 
-        assertThat(log, containsString("ERROR: Cleanup command failed with code 1"));
+        assertThat(log, containsString("ERROR: Cleanup command `mkdir " + pre.getRemote() + "' failed with code 1"));
+        assertThat(log, containsString("ERROR: Cleanup command `mkdir " + post.getRemote() + "' failed with code 1"));
         assertThat(log, containsString("mkdir: cannot create directory ‘" + pre.getRemote() + "’: File exists"));
         assertThat(log, containsString("mkdir: cannot create directory ‘" + post.getRemote() + "’: File exists"));
     }


### PR DESCRIPTION
When using the external deletion command option with a workspace containing many files to delete, the build log is filled with lots of spam like
```
[WS-CLEANUP] Using command: sudo rm -rf /file1 
[WS-CLEANUP] Using command: sudo rm -rf /file1
[WS-CLEANUP] Using command: sudo rm -rf /file3
[WS-CLEANUP] Using command: sudo rm -rf /file4
```
etc.

This PR adds an option to control whether this debugging message is printed, since it often offers no value, and there's no similar log verbosity when not using an external deletion command.