### PR TITLE
resolve ambiguity about the delete workspace scope

### DIFF
--- a/src/main/webapp/help/patterns.html
+++ b/src/main/webapp/help/patterns.html
@@ -1,4 +1,4 @@
 <div>
-    By default, the entire workspace will be deleted. You can make it more selective by specifying here some file
+    By default, this job's entire workspace will be deleted. You can make it more selective by specifying here some file
     patterns (using Ant syntax) to select only a subset of the workspace.
 </div>


### PR DESCRIPTION
The original language made sound like the entire workspace, ie: `c:\jenkins\workspace\*`, would be removed when only means this job's workspace instead, ie: `c:\jenkins\workspace\my_job\*`.

Just to make sure I went through and confirmed it by running to jobs on one VM's workspace.