### PR TITLE
[FIXED JENKINS-24824] Add option to clean asynchronously if possible

### DIFF
--- a/src/main/java/hudson/plugins/ws_cleanup/PreBuildCleanup.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/PreBuildCleanup.java
@@ -27,14 +27,14 @@ public class PreBuildCleanup extends BuildWrapper {
 	private final List<Pattern> patterns;
 	private final boolean deleteDirs;
 	private final String cleanupParameter;
-        private final String externalDelete;
+	private final String externalDelete;
 
 	@DataBoundConstructor
 	public PreBuildCleanup(List<Pattern> patterns, boolean deleteDirs, String cleanupParameter, String externalDelete) {
 		this.patterns = patterns;
 		this.deleteDirs = deleteDirs;
 		this.cleanupParameter = cleanupParameter;
-                this.externalDelete = externalDelete;
+		this.externalDelete = externalDelete;
 	}
 
 	public List<Pattern> getPatterns(){
@@ -49,7 +49,7 @@ public class PreBuildCleanup extends BuildWrapper {
 		return this.cleanupParameter;
 	}
 	
-        public String getExternalDelete() {
+    public String getExternalDelete() {
             return this.externalDelete;
         }
         
@@ -81,7 +81,7 @@ public class PreBuildCleanup extends BuildWrapper {
                
 		if (ws != null) {
 		    listener.getLogger().println(WsCleanup.LOG_PREFIX + "Deleting project workspace...");
-		    RemoteCleaner cleaner = RemoteCleaner.get(patterns, deleteDirs, externalDelete, listener, build);
+		    RemoteCleaner cleaner = RemoteCleaner.get(patterns, deleteDirs, externalDelete, false, listener, build);
 			try {
 				// Retry the operation a couple of times,
 				int retry = 3;
@@ -91,7 +91,11 @@ public class PreBuildCleanup extends BuildWrapper {
 							return;
 						}
 
-						cleaner.perform(ws);
+						if ((patterns == null || patterns.isEmpty()) && (externalDelete == null || externalDelete.isEmpty())) {
+							ws.deleteRecursive();
+						} else {
+							cleaner.perform(ws);
+						}
 						listener.getLogger().println(WsCleanup.LOG_PREFIX + "Done");
 						break;
 					} catch (IOException e) {

--- a/src/main/java/hudson/plugins/ws_cleanup/RemoteCleaner.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/RemoteCleaner.java
@@ -42,10 +42,11 @@ import java.util.List;
             List<Pattern> patterns,
             boolean deleteDirs,
             String externalDelete,
+            boolean cleanAsynchronously,
             BuildListener listener,
             AbstractBuild<?, ?> build
     ) {
-        boolean wipeout = (patterns == null || patterns.isEmpty())
+        boolean wipeout = cleanAsynchronously && (patterns == null || patterns.isEmpty())
                 && (externalDelete == null || externalDelete.isEmpty())
         ;
 

--- a/src/main/java/hudson/plugins/ws_cleanup/WsCleanup.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/WsCleanup.java
@@ -49,11 +49,12 @@ public class WsCleanup extends Notifier implements MatrixAggregatable {
     private final boolean notFailBuild;
     private final boolean cleanupMatrixParent;
     private final String externalDelete;
+    private final boolean cleanAsynchronously;
 
     @DataBoundConstructor
     // FIXME can't get repeteable to work with a List<String>
     public WsCleanup(List<Pattern> patterns, boolean deleteDirs, final boolean cleanWhenSuccess, final boolean cleanWhenUnstable, final boolean cleanWhenFailure,
-                     final boolean cleanWhenNotBuilt, final boolean cleanWhenAborted, final boolean notFailBuild, final boolean cleanupMatrixParent, final String externalDelete) {
+                     final boolean cleanWhenNotBuilt, final boolean cleanWhenAborted, final boolean notFailBuild, final boolean cleanupMatrixParent, final String externalDelete, final boolean cleanAsynchronously) {
         this.patterns = patterns;
         this.deleteDirs = deleteDirs;
         this.notFailBuild = notFailBuild;
@@ -64,6 +65,7 @@ public class WsCleanup extends Notifier implements MatrixAggregatable {
         this.cleanWhenNotBuilt = cleanWhenNotBuilt;
         this.cleanWhenAborted = cleanWhenAborted;
         this.externalDelete = externalDelete;
+        this.cleanAsynchronously = cleanAsynchronously;
     }
 
     public Object readResolve(){
@@ -135,6 +137,10 @@ public class WsCleanup extends Notifier implements MatrixAggregatable {
         return this.externalDelete;
     }
 
+    public boolean isCleanAsynchronously() {
+        return cleanAsynchronously;
+    }
+
     private boolean shouldCleanBuildBasedOnState(Result result) {
         if(result.equals(Result.SUCCESS))
             return this.cleanWhenSuccess;
@@ -161,7 +167,7 @@ public class WsCleanup extends Notifier implements MatrixAggregatable {
                 listener.getLogger().println(WsCleanup.LOG_PREFIX + "Skipped based on build state " + build.getResult());
                 return true;
             }
-            RemoteCleaner cleaner = RemoteCleaner.get(patterns, deleteDirs, externalDelete, listener, build);
+            RemoteCleaner cleaner = RemoteCleaner.get(patterns, deleteDirs, externalDelete, cleanAsynchronously, listener, build);
             cleaner.perform(workspace);
             listener.getLogger().println(WsCleanup.LOG_PREFIX + "done");
         } catch (Exception ex) {

--- a/src/main/resources/hudson/plugins/ws_cleanup/WsCleanup/config.jelly
+++ b/src/main/resources/hudson/plugins/ws_cleanup/WsCleanup/config.jelly
@@ -45,5 +45,8 @@ DEALINGS IN THE SOFTWARE. -->
         <f:entry title="${%External Deletion Command}" help="/plugin/ws-cleanup/help/externalDelete.html">
             <f:textbox field="externalDelete" />
         </f:entry>
+        <f:entry title="${%Clean asynchronously}" help="/plugin/ws-cleanup/help/cleanAsynchronously.html">
+            <f:checkbox field="cleanAsynchronously" checked="${it.cleanAsynchronously}" />
+        </f:entry>
     </f:advanced>
 </j:jelly>

--- a/src/main/webapp/help/cleanAsynchronously.html
+++ b/src/main/webapp/help/cleanAsynchronously.html
@@ -1,0 +1,4 @@
+<div>
+    If this option is selected, the clean will be asynchronously if it's possible.
+    To do this, the current workspace will be renamed "_ws-cleanup_&lt;currentTimeMillis&gt;" to avoid conflicts, and next it will be deleted.
+</div>

--- a/src/test/java/hudson/plugins/ws_cleanup/CleanupTest.java
+++ b/src/test/java/hudson/plugins/ws_cleanup/CleanupTest.java
@@ -181,7 +181,7 @@ public class CleanupTest {
 
         p.getBuildWrappersList().add(new PreBuildCleanup(Collections.<Pattern>emptyList(), false, null, command));
         p.getPublishersList().add(new WsCleanup(
-                Collections.<Pattern>emptyList(), false, true, true, true, true, true, true, true, command
+                Collections.<Pattern>emptyList(), false, true, true, true, true, true, true, true, command, false
         ));
 
         FreeStyleBuild build = j.buildAndAssertSuccess(p);
@@ -196,7 +196,7 @@ public class CleanupTest {
     private WsCleanup wipeoutPublisher() {
         return new WsCleanup(Collections.<Pattern>emptyList(), false,
                 true, true, true, true, true, true, true, // run always
-        null);
+        null, true);
     }
 
     private void populateWorkspace(FreeStyleProject p, String filename) throws Exception {


### PR DESCRIPTION
This PR is base on discussion here : https://issues.jenkins-ci.org/browse/JENKINS-24824
And particularly this comment : 
**I think what needs to be done for asynch plugin is to fail the build somehow if the deletion fails and report the error. Also, it would be nice if user could select between asynch and synch delete instead of having to downgrade all the way to 0.23.**

So I propose a new option "cleanAsynchronously" in RemoteCleaner, in order to specify if we want clean the workspace aynschronously or not. IMHO in PreBuildCleanup, the clean must be always synch.

I will try to give another PR to bring back asynch error in job console trace, but without this, we can switch synch mode now et see errors if we have it.
