### PR TITLE
[FIX] If cleanup should be able to mark build as failed, it needs to be run before finalizers

### DIFF
--- a/src/main/java/hudson/plugins/ws_cleanup/WsCleanup.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/WsCleanup.java
@@ -244,7 +244,7 @@ public class WsCleanup extends Notifier implements MatrixAggregatable, SimpleBui
     
     @Override
     public boolean needsToRunAfterFinalized() {
-        return true;
+            return notFailBuild;
     }
     
     //TODO remove if https://github.com/jenkinsci/jenkins/pull/834 is accepted


### PR DESCRIPTION
So, according docs:
```java
    /**
     * Return true if this {@link Publisher} needs to run after the build result is
     * fully finalized.
     *
     * <p>
     * The execution of normal {@link Publisher}s are considered within a part
     * of the build. This allows publishers to mark the build as a failure, or
     * to include their execution time in the total build time.
     *
     * <p>
     * So normally, that is the preferrable behavior, but in a few cases
     * this is problematic. One of such cases is when a publisher needs to
     * trigger other builds, which in turn need to see this build as a
     * completed build. Those plugins that need to do this can return true
     * from this method, so that the {@link #perform(AbstractBuild, Launcher, BuildListener)} 
     * method is called after the build is marked as completed.
     *
     * <p>
     * When {@link Publisher} behaves this way, note that they can no longer
     * change the build status anymore.
     *
     * @since 1.153
     */
    public boolean needsToRunAfterFinalized() {
        return false;
    }
```
So, if `needsToRunAfterFinalized` returns `true`. `Publisher` is not able anymore to change build result (code from last Jenkins, but it's quite old);
```java
protected final boolean performAllBuildSteps(BuildListener listener, Iterable<? extends BuildStep> buildSteps, boolean phase) throws InterruptedException, IOException {
            boolean r = true;
            for (BuildStep bs : buildSteps) {
                if ((bs instanceof Publisher && ((Publisher)bs).needsToRunAfterFinalized()) ^ phase)
                    try {
                        if (!perform(bs,listener)) {
                            LOGGER.log(Level.FINE, "{0} : {1} failed", new Object[] {AbstractBuild.this, bs});
                            r = false;
                            if (phase) { // Phase would be "false" if needsToRunAfterFinalized returns "true"
                                setResult(Result.FAILURE);
                            }
                        }
            ...
        }
```

Unfortunately, I failed to write test for this fix, so, if you have any suggestion how to perform it - it would be nice.