### PR TITLE
[JENKINS-37054] Add symbol annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,12 +14,12 @@
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Workspace+Cleanup+Plugin</url>
 
   <properties>
-    <jenkins.version>1.609</jenkins.version>
-    <java.level>6</java.level>
-    <workflow-job.version>1.4.3</workflow-job.version>
-    <workflow-cps.version>1.4.3</workflow-cps.version>
-    <workflow-basic-steps.version>1.4.3</workflow-basic-steps.version>
-    <workflow-durable-task-step.version>1.4.3</workflow-durable-task-step.version>
+    <jenkins.version>1.642.1</jenkins.version>
+    <java.level>7</java.level>
+    <workflow-job.version>2.4</workflow-job.version>
+    <workflow-cps.version>2.10</workflow-cps.version>
+    <workflow-basic-steps.version>2.1</workflow-basic-steps.version>
+    <workflow-durable-task-step.version>2.4</workflow-durable-task-step.version>
   </properties>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,10 @@
   <properties>
     <jenkins.version>1.609</jenkins.version>
     <java.level>6</java.level>
-    <workflow.version>1.4.3</workflow.version>
+    <workflow-job.version>1.4.3</workflow-job.version>
+    <workflow-cps.version>1.4.3</workflow-cps.version>
+    <workflow-basic-steps.version>1.4.3</workflow-basic-steps.version>
+    <workflow-durable-task-step.version>1.4.3</workflow-durable-task-step.version>
   </properties>
 
   <developers>
@@ -46,6 +49,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>1.5</version>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
       <version>1.2.1</version>
@@ -54,19 +62,25 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <version>${workflow.version}</version>
+      <version>${workflow-job.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>${workflow.version}</version>
+      <version>${workflow-cps.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
-      <version>${workflow.version}</version>
+      <version>${workflow-basic-steps.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-durable-task-step</artifactId>
+      <version>${workflow-durable-task-step.version}</version>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>

--- a/src/main/java/hudson/plugins/ws_cleanup/WsCleanup.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/WsCleanup.java
@@ -19,6 +19,7 @@ import hudson.tasks.Publisher;
 import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -253,7 +254,8 @@ public class WsCleanup extends Notifier implements MatrixAggregatable, SimpleBui
     public boolean isMatrixProject(Object o) {
         return o instanceof MatrixProject;
     }
-    
+
+    @Symbol("cleanWs")
     @Extension(ordinal=-9999)
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 

--- a/src/test/java/hudson/plugins/ws_cleanup/CleanupTest.java
+++ b/src/test/java/hudson/plugins/ws_cleanup/CleanupTest.java
@@ -27,7 +27,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
 import static org.hamcrest.Matchers.*;
 
@@ -55,7 +54,6 @@ import java.util.List;
 import java.util.concurrent.Future;
 
 import hudson.util.DescribableList;
-import hudson.util.VersionNumber;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -65,9 +63,6 @@ import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
-
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 
 public class CleanupTest {
 
@@ -269,11 +264,8 @@ public class CleanupTest {
         verifyFileExists("foo.txt");
     }
 
-    @Test
-    @Issue("JENKINS-37054")
+    @Test @Issue("JENKINS-37054")
     public void symbolAnnotationWorkspaceCleanup() throws Exception {
-        assumeSymbolDependencies();
-
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("" +
                 "node { \n" +
@@ -291,11 +283,8 @@ public class CleanupTest {
         assertThat(ws.getRoot().listFiles(), nullValue());
     }
 
-    @Test
-    @Issue("JENKINS-37054")
+    @Test @Issue("JENKINS-37054")
     public void symbolWorkspaceCleanupAnnotationUsingPattern() throws Exception {
-        assumeSymbolDependencies();
-
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("" +
                 "node { \n" +
@@ -314,11 +303,8 @@ public class CleanupTest {
         verifyFileExists("foo.txt");
     }
 
-    @Test
-    @Issue("JENKINS-37054")
+    @Test @Issue("JENKINS-37054")
     public void symbolAnnotationWorkspaceCleanupUnlessBuildFails() throws Exception {
-        assumeSymbolDependencies();
-
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("" +
                 "node { \n" +
@@ -338,34 +324,6 @@ public class CleanupTest {
         j.assertLogContains("[WS-CLEANUP] Deleting project workspace...[WS-CLEANUP] Skipped based on build state FAILURE", run);
 
         verifyFileExists("foo.txt");
-    }
-
-    /**
-     * To use the @Symbol annotation in tests, minimum workflow-cps version 2.10 is required.
-     * This dependency comes with other dependency version requirements, as stated by this method.
-     * To run tests restricted by this method, type
-     * <pre>
-     * mvn clean install -Djenkins.version=1.642.1 -Djava.level=7 -Dworkflow-job.version=2.4 -Dworkflow-basic-steps.version=2.1 -Dworkflow-cps.version=2.10 -Dworkflow-durable-task-step.version=2.4
-     * </pre>
-     */
-    private static void assumeSymbolDependencies() {
-        assumePropertyIsGreaterThanOrEqualTo(System.getProperty("jenkins.version"), "1.642.1");
-        assumePropertyIsGreaterThanOrEqualTo(System.getProperty("java.level"), "7");
-        assumePropertyIsGreaterThanOrEqualTo(System.getProperty("workflow-job.version"), "2.4");
-        assumePropertyIsGreaterThanOrEqualTo(System.getProperty("workflow-basic-steps.version"), "2.1");
-        assumePropertyIsGreaterThanOrEqualTo(System.getProperty("workflow-cps.version"), "2.10");
-        assumePropertyIsGreaterThanOrEqualTo(System.getProperty("workflow-durable-task-step.version"), "2.4");
-    }
-
-    /**
-     * Checks if the given property is not null, and if it's greater than or equal to the given version.
-     *
-     * @param property the property to be checked
-     * @param version  the version on which the property is checked against
-     */
-    private static void assumePropertyIsGreaterThanOrEqualTo(@CheckForNull String property, @Nonnull String version) {
-        assumeThat(property, notNullValue());
-        assumeThat(new VersionNumber(property).compareTo(new VersionNumber(version)), is(greaterThanOrEqualTo(0)));
     }
 
     private void verifyFileExists(String fileName) {


### PR DESCRIPTION
Related to issue [[JENKINS-37054]](https://issues.jenkins-ci.org/browse/JENKINS-37054)

Summary of this pull request:
- [X] Add `@Symbol` annotation

With the `@Symbol` annotation, the Pipeline code can drop the `$class` syntax

Examples:
1. `wsCleanup()`  
   instead of  
   ~~`step([$class: 'WsCleanup'])`~~
2. `wsCleanup cleanWhenFailure: false`  
   instead of  
   ~~`step ([$class: 'WsCleanup', cleanWhenFailure: false])`~~
3. `wsCleanup patterns: [[pattern: 'bar.*', type: 'INCLUDE']]`  
   instead of  
   ~~`step([$class: 'WsCleanup', patterns: [[pattern: 'bar.*', type: 'INCLUDE']]])`~~

CC @olivergondza @oleg-nenashev @martinda
