### PR TITLE
Grab FilePath each time in case Channel is dead.

### DIFF
--- a/src/main/java/hudson/plugins/ws_cleanup/Wipeout.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/Wipeout.java
@@ -87,11 +87,8 @@ import javax.annotation.Nonnull;
         // TODO node can get renamed which should be reflected here
         private final String node;
         private final String path;
-        @SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
-        private transient FilePath ws;
 
         private DisposableImpl(FilePath ws, String computer) {
-            this.ws = ws;
             this.node = computer;
             this.path = ws.getRemote();
         }
@@ -99,13 +96,12 @@ import javax.annotation.Nonnull;
         @Nonnull public State dispose() throws Throwable {
             Jenkins j = Jenkins.getInstance();
             if (j == null) return State.TO_DISPOSE; // Going down?
-
-            if (ws == null) {
-                Computer computer = j.getComputer(node);
-                if (computer == null) return State.PURGED; // Removed or discarded cloud machine
-
-                ws = new FilePath(computer.getChannel(), path);
-            }
+                
+            Computer computer = j.getComputer(node);
+            if (computer == null) return State.PURGED; // Removed or discarded cloud machine
+            
+            FilePath ws = new FilePath(computer.getChannel(), path);
+            
             try {
                 ws.deleteRecursive();
             } catch (IOException ex) {


### PR DESCRIPTION
This bug shows up as a memory leak in systems that have a lot of node delete operations shortly after jobs are finished.  FIlePath contains a reference to the channel.  When the node is deleted (or the connection dies, etc.) the channel is no longer valid, causing exceptions (of various types).  These exceptions are then interpreted as a need to retry, and we will slowly build up operations in the async cleanup backlog until jenkins runs out of memory.

Instead, grab the computer (which would be null if we lost connection) and remote workspace each time we want to attempt cleanup.