### PR TITLE
Handling `deleteCommand` being empty string or containing whitespace

### DIFF
--- a/src/main/java/hudson/plugins/ws_cleanup/Cleanup.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/Cleanup.java
@@ -92,7 +92,7 @@ class Cleanup extends RemoteCleaner implements FileCallable<Object> {
         }
 
         for (String path : toDelete) {
-            if (deleteCommand != null) {
+            if (deleteCommand != null && !deleteCommand.trim().isEmpty()) {
                 List<String> cmdList = fixQuotesAndExpand((new File(f, path)).getPath());
                 doDelete(cmdList);
             } else {
@@ -103,7 +103,7 @@ class Cleanup extends RemoteCleaner implements FileCallable<Object> {
         //not followed symlinks are returned as absolute paths, needs to be removed separately
         final String[] nonFollowedSymlinks = ds.getNotFollowedSymlinks();
         for (String link : nonFollowedSymlinks) {
-            if (deleteCommand != null) {
+            if (deleteCommand != null && !deleteCommand.trim().isEmpty()) {
                 List<String> cmdList = fixQuotesAndExpand((new File(link)).getPath());
                 doDelete(cmdList);
             } else {

--- a/src/main/java/hudson/plugins/ws_cleanup/Cleanup.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/Cleanup.java
@@ -37,7 +37,7 @@ class Cleanup extends RemoteCleaner implements FileCallable<Object> {
         this.deleteDirs = deleteDirs;
         this.listener = listener;
         this.patterns = (patterns == null) ? Collections.<Pattern>emptyList() : patterns;
-        this.deleteCommand = (command == null || command.isEmpty()) ? null : command;
+        this.deleteCommand = (command == null || command.trim().isEmpty()) ? null : command;
 
         if (environment != null && deleteCommand != null) { // allow slave environment to overwrite delete cmd
             this.deleteCommand = environment.getEnvVars().get(command);
@@ -92,7 +92,7 @@ class Cleanup extends RemoteCleaner implements FileCallable<Object> {
         }
 
         for (String path : toDelete) {
-            if (deleteCommand != null && !deleteCommand.trim().isEmpty()) {
+            if (deleteCommand != null) {
                 List<String> cmdList = fixQuotesAndExpand((new File(f, path)).getPath());
                 doDelete(cmdList);
             } else {
@@ -103,7 +103,7 @@ class Cleanup extends RemoteCleaner implements FileCallable<Object> {
         //not followed symlinks are returned as absolute paths, needs to be removed separately
         final String[] nonFollowedSymlinks = ds.getNotFollowedSymlinks();
         for (String link : nonFollowedSymlinks) {
-            if (deleteCommand != null && !deleteCommand.trim().isEmpty()) {
+            if (deleteCommand != null) {
                 List<String> cmdList = fixQuotesAndExpand((new File(link)).getPath());
                 doDelete(cmdList);
             } else {

--- a/src/main/java/hudson/plugins/ws_cleanup/RemoteCleaner.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/RemoteCleaner.java
@@ -48,7 +48,7 @@ import java.util.List;
             Run<?, ?> build
     ) {
         boolean wipeout = (patterns == null || patterns.isEmpty())
-                && (externalDelete == null || externalDelete.isEmpty())
+                && (externalDelete == null || externalDelete.trim().isEmpty())
         ;
 
         if (wipeout) return Wipeout.getInstance();

--- a/src/test/java/hudson/plugins/ws_cleanup/CleanupTest.java
+++ b/src/test/java/hudson/plugins/ws_cleanup/CleanupTest.java
@@ -326,6 +326,44 @@ public class CleanupTest {
         verifyFileExists("foo.txt");
     }
 
+    @Test
+    public void doNotRunExternalCommandWhenNull() throws Exception {
+        String command = null;
+
+        FreeStyleProject p = j.jenkins.createProject(FreeStyleProject.class, "sut");
+        populateWorkspace(p, "content.txt");
+
+        p.getBuildWrappersList().add(
+                new PreBuildCleanup(
+                        Collections.<Pattern>emptyList(),
+                        false,
+                        null,
+                        command));
+
+        FreeStyleBuild build = j.buildAndAssertSuccess(p);
+
+        assertWorkspaceCleanedUp(build);
+    }
+
+    @Test
+    public void doNotRunExternalCommandWhenWhitespace() throws Exception {
+        String command = "  \n  ";
+
+        FreeStyleProject p = j.jenkins.createProject(FreeStyleProject.class, "sut");
+        populateWorkspace(p, "content.txt");
+
+        p.getBuildWrappersList().add(
+                new PreBuildCleanup(
+                        Collections.<Pattern>emptyList(),
+                        false,
+                        null,
+                        command));
+
+        FreeStyleBuild build = j.buildAndAssertSuccess(p);
+
+        assertWorkspaceCleanedUp(build);
+    }
+
     private void verifyFileExists(String fileName) {
         File[] files = ws.getRoot().listFiles();
         assertThat(files, notNullValue());


### PR DESCRIPTION
If `deleteCommand` contains whitespace or is empty, the cleanup workspace command might launch arbitrary processes if the folder to be cleaned contains executable files. This is potentially dangerous.
