### PR TITLE
[JENKINS-61856] Add the ability to "Delete workspace before build starts" in a declarative pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 There is a single [step](https://jenkins.io/doc/pipeline/steps/ws-cleanup) to be used whenever workspace is allocated. 
 
-## Job DSL
+### Scripted pipeline (Job DSL)
 
 Examples:
 
@@ -37,6 +37,42 @@ job("foo") {
                     pattern('.gitignore')
                 }
             }
+        }
+    }
+}
+```
+
+### Descriptive pipeline
+
+Examples:
+
+```groovy
+pipeline { 
+    agent any
+    options {
+        skipDefaultCheckout(true)
+    }
+    stages {
+        stage('Build') {
+            steps {
+                // Clean before build
+                preBuildCleanWs(cleanupParameter: 'CLEANUP',
+                        deleteDirs: true,
+                        patterns: [[pattern: '**/target/**', type: 'INCLUDE']]) {
+                    checkout scm
+                    echo "Building ${env.JOB_NAME}..."
+                }
+            }
+        }
+    }
+    post {
+        // Clean after build
+        always {
+            cleanWs(cleanWhenNotBuilt: false,
+                    deleteDirs: true,
+                    disableDeferredWipeout: true,
+                    notFailBuild: true,
+                    patterns: [[pattern: '.gitignore', type: 'INCLUDE'], [pattern: '.propsfile', type: 'EXCLUDE']])
         }
     }
 }

--- a/src/main/java/hudson/plugins/ws_cleanup/PreBuildCleanup.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/PreBuildCleanup.java
@@ -5,6 +5,7 @@ import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.Util;
 import hudson.model.AbstractProject;
 import hudson.model.Descriptor;
 import hudson.model.Run;
@@ -12,13 +13,17 @@ import hudson.model.TaskListener;
 import hudson.tasks.BuildWrapper;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import hudson.tasks.BuildWrapperDescriptor;
 import jenkins.tasks.SimpleBuildWrapper;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * @author vjuranek
@@ -27,18 +32,22 @@ public class PreBuildCleanup extends SimpleBuildWrapper {
 
 	private static final Logger LOGGER = Logger.getLogger(PreBuildCleanup.class.getName());
 
-	private final List<Pattern> patterns;
-	private final boolean deleteDirs;
-	private final String cleanupParameter;
-	private final String externalDelete;
-	private final boolean disableDeferredWipeout;
+	private List<Pattern> patterns = Collections.emptyList();
+	private boolean deleteDirs;
+	private String cleanupParameter = StringUtils.EMPTY;
+	private String externalDelete = StringUtils.EMPTY;
+	private boolean disableDeferredWipeout;
+
+	@DataBoundConstructor
+	public PreBuildCleanup() {
+	}
 
 	@Deprecated
 	public PreBuildCleanup(List<Pattern> patterns, boolean deleteDirs, String cleanupParameter, String externalDelete) {
 		this(patterns, deleteDirs, cleanupParameter, externalDelete, false);
 	}
 
-	@DataBoundConstructor
+	@Deprecated
     public PreBuildCleanup(List<Pattern> patterns, boolean deleteDirs, String cleanupParameter,
                            String externalDelete, boolean disableDeferredWipeout) {
         this.patterns = patterns;
@@ -76,6 +85,31 @@ public class PreBuildCleanup extends SimpleBuildWrapper {
 	@Override
 	protected boolean runPreCheckout() {
 		return true;
+	}
+
+	@DataBoundSetter
+	public void setCleanupParameter(String cleanupParameter) {
+		this.cleanupParameter = Util.fixNull(cleanupParameter);
+	}
+
+	@DataBoundSetter
+	public void setDeleteDirs(boolean deleteDirs) {
+		this.deleteDirs = deleteDirs;
+	}
+
+	@DataBoundSetter
+	public void setDisableDeferredWipeout(boolean disableDeferredWipeout) {
+		this.disableDeferredWipeout = disableDeferredWipeout;
+	}
+
+	@DataBoundSetter
+	public void setExternalDelete(String externalDelete) {
+		this.externalDelete = Util.fixNull(externalDelete);
+	}
+
+	@DataBoundSetter
+	public void setPatterns(List<Pattern> patterns) {
+		this.patterns = patterns;
 	}
 
 	@Override
@@ -124,6 +158,7 @@ public class PreBuildCleanup extends SimpleBuildWrapper {
 		}
 	}
 
+	@Symbol("preBuildCleanWs")
 	@Extension(ordinal=9999)
 	public static final class DescriptorImpl extends BuildWrapperDescriptor {
 


### PR DESCRIPTION
This pull request contains a refactoring to extend SimpleBuildWrapper instead of BuildWrapper, which makes it possible to use the this wrapper class in a declarative pipeline.

Things left to to:
* Fix so that you can use a shorthand notation in the Jenkinsfile instead of having to know the class. I haven't found out how to do that yet.
* Add documentation for declarative pipeline usage.

Question
Even though I have implemented runPreCheckout() to return true, I have not been able to use it the way I thought I should.

This works:
```
pipeline { 
    agent any
    options {
        skipDefaultCheckout(true)
    }
    stages {
        stage('Build') {
            steps {
                wrap([$class: 'PreBuildCleanup', cleanupParameter: 'CLEANUP']) {
                    checkout scm
                    echo "Building ${env.JOB_NAME}..."
                }
            }
        }
    }
}
```

But I thought that I should be able to do this. I'm using Subversion with "Lightweight checkout" checked. This however runs the implicit default scm checkout before PreBuildCleanup.
```
pipeline { 
    agent any
    stages {
        stage('Build') {
            steps {
                wrap([$class: 'PreBuildCleanup', cleanupParameter: 'CLEANUP']) {
                    echo "Building ${env.JOB_NAME}..."
                }
            }
        }
    }
}
```