### PR TITLE
Try re-enabling memory-intensive tests on Windows

### DIFF
--- a/src/test/java/hudson/plugins/ws_cleanup/PreBuildCleanupTest.java
+++ b/src/test/java/hudson/plugins/ws_cleanup/PreBuildCleanupTest.java
@@ -16,7 +16,6 @@ import hudson.plugins.ws_cleanup.Pattern.PatternType;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.EnvironmentVariablesNodeProperty.Entry;
 
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -62,10 +61,6 @@ public class PreBuildCleanupTest {
     @Test
     @LocalData
     public void testCleanWorkspaceByDeleteCommandInNodePropertyIncludeDirectories() throws Exception {
-        Assume.assumeFalse(
-                "TODO Windows ACI agents do not have enough memory to run this test",
-                Functions.isWindows());
-
         FreeStyleProject project = j.createFreeStyleProject("project1");
         Slave slave = j.createOnlineSlave();
         project.setAssignedLabel(slave.getSelfLabel());
@@ -97,10 +92,6 @@ public class PreBuildCleanupTest {
     @Test
     @LocalData
     public void testCleanWorkspaceByDeleteCommandInNodePropertyWithoutDirectory() throws Exception {
-        Assume.assumeFalse(
-                "TODO Windows ACI agents do not have enough memory to run this test",
-                Functions.isWindows());
-
         FreeStyleProject project = j.createFreeStyleProject("project1");
         Slave slave = j.createOnlineSlave();
         project.setAssignedLabel(slave.getSelfLabel());


### PR DESCRIPTION
These tests were disabled a while ago on Windows due to the Windows ACI agents not having enough memory. Perhaps they'll work now?