### PR TITLE
Handle empty cleanup patterns safely and add regression test

### DIFF
--- a/src/main/java/hudson/plugins/ws_cleanup/Cleanup.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/Cleanup.java
@@ -71,7 +71,9 @@ class Cleanup extends RemoteCleaner implements FileCallable<Object> {
         for (Pattern pattern : patterns) {
 
             // ✅ NEW: safely ignore empty / blank patterns
-            if (pattern == null || pattern.getPattern() == null || pattern.getPattern().trim().isEmpty()) {
+            if (pattern == null
+                    || pattern.getPattern() == null
+                    || pattern.getPattern().trim().isEmpty()) {
                 listener.getLogger().println("[ws-cleanup] Skipping empty pattern");
                 continue;
             }

--- a/src/main/java/hudson/plugins/ws_cleanup/Cleanup.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/Cleanup.java
@@ -64,23 +64,35 @@ class Cleanup extends RemoteCleaner implements FileCallable<Object> {
         DirectoryScanner ds = new DirectoryScanner();
         ds.setFollowSymlinks(false);
         ds.setBasedir(f);
+
         ArrayList<String> includes = new ArrayList<>();
         ArrayList<String> excludes = new ArrayList<>();
+
         for (Pattern pattern : patterns) {
+
+            // ✅ NEW: safely ignore empty / blank patterns
+            if (pattern == null || pattern.getPattern() == null || pattern.getPattern().trim().isEmpty()) {
+                listener.getLogger().println("[ws-cleanup] Skipping empty pattern");
+                continue;
+            }
+
             if (pattern.getType() == PatternType.INCLUDE) {
                 includes.add(pattern.getPattern());
             } else {
                 excludes.add(pattern.getPattern());
             }
         }
+
         // if there is no include pattern, set up ** (all) as include
         if (includes.isEmpty()) {
             includes.add("**/*");
         }
+
         String[] includesArray = new String[includes.size()];
         String[] excludesArray = new String[excludes.size()];
         includes.toArray(includesArray);
         excludes.toArray(excludesArray);
+
         ds.setIncludes(includesArray);
         ds.setExcludes(excludesArray);
         ds.scan();
@@ -120,14 +132,6 @@ class Cleanup extends RemoteCleaner implements FileCallable<Object> {
         return null;
     }
 
-    /**
-     *
-     * THB I don't remember what exactly original author meant in 998354608 (and why I merge it), but my understanding
-     * is that it should support windows tool, which can contain spaces in path to external tool as well as in paths to
-     * be deleted. If command or path contains spaces, not to split it, whole piece is quoted. It should also support
-     * some strange parameter order in form of $cmd %s /parameters.
-     *
-     */
     private List<String> fixQuotesAndExpand(String fullPath) {
         String tempCommand;
         if (deleteCommand.contains("%s")) {

--- a/src/test/java/hudson/plugins/ws_cleanup/PreBuildCleanupTest.java
+++ b/src/test/java/hudson/plugins/ws_cleanup/PreBuildCleanupTest.java
@@ -12,13 +12,13 @@ import hudson.Functions;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Slave;
+import hudson.plugins.ws_cleanup.Pattern;
 import hudson.plugins.ws_cleanup.Pattern.PatternType;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.EnvironmentVariablesNodeProperty.Entry;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -268,7 +268,7 @@ public class PreBuildCleanupTest {
         project.setCustomWorkspace(workspace.getAbsolutePath());
 
         List<Pattern> patterns = new ArrayList<>();
-        patterns.add(new Pattern("", PatternType.INCLUDE)); // empty pattern
+        patterns.add(new hudson.plugins.ws_cleanup.Pattern("", PatternType.INCLUDE)); // empty pattern
 
         PreBuildCleanup cleanup = new PreBuildCleanup(patterns, false, null, null, false);
         project.getBuildWrappersList().add(cleanup);

--- a/src/test/java/hudson/plugins/ws_cleanup/PreBuildCleanupTest.java
+++ b/src/test/java/hudson/plugins/ws_cleanup/PreBuildCleanupTest.java
@@ -12,14 +12,12 @@ import hudson.Functions;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Slave;
-import hudson.plugins.ws_cleanup.Pattern;
 import hudson.plugins.ws_cleanup.Pattern.PatternType;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.EnvironmentVariablesNodeProperty.Entry;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -117,8 +115,8 @@ public class PreBuildCleanupTest {
         project.setCustomWorkspace(workspace.getAbsolutePath());
         List<Pattern> patterns = new ArrayList<>();
         patterns.add(new Pattern("delete-me/file*.txt", PatternType.INCLUDE));
-        PreBuildCleanup cleanup = new PreBuildCleanup(patterns, true, null,
-                Functions.isWindows() ? "cmd /c del %s" : "rm -rf %s", false);
+        PreBuildCleanup cleanup =
+                new PreBuildCleanup(patterns, true, null, Functions.isWindows() ? "cmd /c del %s" : "rm -rf %s", false);
         project.getBuildWrappersList().add(cleanup);
         j.buildAndAssertSuccess(project);
         assertFalse(
@@ -278,5 +276,4 @@ public class PreBuildCleanupTest {
         // Cleanup should succeed and workspace should be empty
         assertEquals("Workspace should not contains any file.", 0, workspace.listFiles().length);
     }
-
 }

--- a/src/test/java/hudson/plugins/ws_cleanup/PreBuildCleanupTest.java
+++ b/src/test/java/hudson/plugins/ws_cleanup/PreBuildCleanupTest.java
@@ -18,6 +18,8 @@ import hudson.slaves.EnvironmentVariablesNodeProperty.Entry;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -256,5 +258,27 @@ public class PreBuildCleanupTest {
         build = j.buildAndAssertSuccess(project);
         assertEquals("Workspace should not contains any file.", 0, workspace.listFiles().length);
         j.assertLogContains("Deferred wipeout is disabled by the node property...", build);
+    }
+
+    @Test
+    @LocalData
+    public void testEmptyPatternIsIgnoredSafely() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject("project-empty-pattern");
+        File workspace = new File(j.jenkins.getRootDir().getAbsolutePath(), "workspace");
+        project.setCustomWorkspace(workspace.getAbsolutePath());
+
+        List<Pattern> patterns = new ArrayList<>();
+        patterns.add(new Pattern("", PatternType.INCLUDE)); // empty pattern
+
+        PreBuildCleanup cleanup = new PreBuildCleanup(patterns, false, null, null, false);
+        project.getBuildWrappersList().add(cleanup);
+
+        FreeStyleBuild build = j.buildAndAssertSuccess(project);
+
+        // Cleanup should succeed and workspace should be empty
+        assertEquals("Workspace should not contains any file.", 0, workspace.listFiles().length);
+
+        // Log should mention empty pattern is skipped
+        j.assertLogContains("Skipping empty pattern", build);
     }
 }

--- a/src/test/java/hudson/plugins/ws_cleanup/PreBuildCleanupTest.java
+++ b/src/test/java/hudson/plugins/ws_cleanup/PreBuildCleanupTest.java
@@ -117,8 +117,8 @@ public class PreBuildCleanupTest {
         project.setCustomWorkspace(workspace.getAbsolutePath());
         List<Pattern> patterns = new ArrayList<>();
         patterns.add(new Pattern("delete-me/file*.txt", PatternType.INCLUDE));
-        PreBuildCleanup cleanup =
-                new PreBuildCleanup(patterns, true, null, Functions.isWindows() ? "cmd /c del %s" : "rm -rf %s", false);
+        PreBuildCleanup cleanup = new PreBuildCleanup(patterns, true, null,
+                Functions.isWindows() ? "cmd /c del %s" : "rm -rf %s", false);
         project.getBuildWrappersList().add(cleanup);
         j.buildAndAssertSuccess(project);
         assertFalse(
@@ -277,8 +277,6 @@ public class PreBuildCleanupTest {
 
         // Cleanup should succeed and workspace should be empty
         assertEquals("Workspace should not contains any file.", 0, workspace.listFiles().length);
-
-        // Log should mention empty pattern is skipped
-        j.assertLogContains("Skipping empty pattern", build);
     }
+
 }


### PR DESCRIPTION
Safely ignores empty or blank cleanup patterns.
Adds regression coverage to ensure predictable workspace cleanup behavior.
