### PR TITLE
Adapt to release drafter v7 configuration change

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,3 @@
 # https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
-_extends: .github
+_extends: github:jenkinsci/.github:/.github/release-drafter.yml
 tag-template: ws-cleanup-$NEXT_MINOR_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Rely on jenkinsci organization release drafter configuration

Release drafter v7 dropped support for `_extends: .github` in the configuration.  It either needs to be removed or replaced with a more complete specification like:

`_extends: github:jenkinsci/.github:/.github/release-drafter.yml`

Adapts to release drafter changes in pull request:

* https://github.com/release-drafter/release-drafter/pull/1475

Replaces pull request:

* https://github.com/jenkinsci/ws-cleanup-plugin/pull/279

### Testing done

* None.  Has worked well in many repositories, not expecting any issues in this repository

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
