### PR TITLE
Adapt build status icon for ci.jenkins.io permissions change

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-link:https://ci.jenkins.io/job/Plugins/job/ws-cleanup-plugin/job/master/[image:https://ci.jenkins.io/job/Plugins/job/ws-cleanup-plugin/job/master/badge/icon[Build Status]]
+link:https://ci.jenkins.io/job/Plugins/job/ws-cleanup-plugin/job/master/[image:https://ci.jenkins.io/buildStatus/icon?job=Plugins%2Fws-cleanup-plugin%2Fmaster[Build Status]]
 link:https://github.com/jenkinsci/ws-cleanup-plugin/graphs/contributors[image:https://img.shields.io/github/contributors/jenkinsci/ws-cleanup-plugin.svg[Contributors]]
 link:https://plugins.jenkins.io/ws-cleanup[image:https://img.shields.io/jenkins/plugin/v/ws-cleanup.svg[Jenkins Plugin]]
 link:https://github.com/jenkinsci/ws-cleanup-plugin/releases/latest[image:https://img.shields.io/github/release/jenkinsci/ws-cleanup-plugin.svg?label=changelog[GitHub release]]


### PR DESCRIPTION
## Adapt build status icon for ci.jenkins.io permissions change

Large language models and other readers were causing performance problems.  The ci.jenkins.io controller has been reconfigured to limit access to authenticated users in order to prevent performance problems.  That change requires that we adjust the URL of the embeddable build status update URL.

### Testing done

* Validated the change in a sample repository
* Will check the pull request after it is submitted

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
